### PR TITLE
Fixes TypeError: Spatie\LaravelPackageTools\PackageServiceProvider::migrationFileExists()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.4|^8.0",
         "drewroberts/media": "^3.0",
         "nesbot/carbon": "^2.44",
-        "tipoff/support": "^1.0.7"
+        "tipoff/support": "^1.0.11"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0",


### PR DESCRIPTION
Fixes `TypeError: Spatie\LaravelPackageTools\PackageServiceProvider::migrationFileExists(): Argument #1 ($migrationFileName) must be of type string, array given, called in /home/runner/work/escape-room/escape-room/vendor/spatie/laravel-package-tools/src/PackageServiceProvider.php on line 55` on prefer-lowest version via this PR: https://github.com/tipoff/support/pull/23

All checks have passed now.