### PR TITLE
Nova Filters

### DIFF
--- a/database/factories/RoomFactory.php
+++ b/database/factories/RoomFactory.php
@@ -25,7 +25,7 @@ class RoomFactory extends Factory
     public function definition()
     {
         return [
-            'location_id'           => randomOrCreate(Location::factory()->create()->id),
+            'location_id'           => randomOrCreate(app('location')),
             'theme_id'              => randomOrCreate(app('theme')),
             'rate_id'               => randomOrCreate(app('rate')),
             'supervision_id'        => randomOrCreate(app('supervision')),

--- a/database/factories/RoomFactory.php
+++ b/database/factories/RoomFactory.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 declare(strict_types=1);
 
@@ -6,6 +6,7 @@ namespace Tipoff\EscapeRoom\Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Tipoff\EscapeRoom\Models\Room;
+use Tipoff\Locations\Models\Location;
 
 class RoomFactory extends Factory
 {
@@ -24,7 +25,7 @@ class RoomFactory extends Factory
     public function definition()
     {
         return [
-            'location_id'           => randomOrCreate(app('location')),
+            'location_id'           => randomOrCreate(Location::factory()->create()->id()),
             'theme_id'              => randomOrCreate(app('theme')),
             'rate_id'               => randomOrCreate(app('rate')),
             'supervision_id'        => randomOrCreate(app('supervision')),

--- a/database/factories/RoomFactory.php
+++ b/database/factories/RoomFactory.php
@@ -25,7 +25,7 @@ class RoomFactory extends Factory
     public function definition()
     {
         return [
-            'location_id'           => randomOrCreate(Location::factory()->create()->id()),
+            'location_id'           => randomOrCreate(Location::factory()->create()->id),
             'theme_id'              => randomOrCreate(app('theme')),
             'rate_id'               => randomOrCreate(app('rate')),
             'supervision_id'        => randomOrCreate(app('supervision')),

--- a/src/Nova/Filters/RoomLocation.php
+++ b/src/Nova/Filters/RoomLocation.php
@@ -23,14 +23,23 @@ class RoomLocation extends Filters
     public $name = 'Location';
 
     /**
-     * Apply the filter to the given query.
+     * Registered filters to operate upon.
+     *
+     * @var array
+     */
+    protected $availableFilters = [
+        'room',
+    ];
+
+    /**
+     * Filter the room query by a given location id.
      *
      * @param  \Illuminate\Http\Request  $request
      * @param  \Illuminate\Database\Eloquent\Builder  $query
      * @param  mixed  $value
      * @return \Illuminate\Database\Eloquent\Builder
      */
-    public function apply(Request $request, $query, $value)
+    public function room(Request $request, $query, $value)
     {
         return $query->whereHas('room', function ($query) use ($value) {
             $query->where('rooms.location_id', $value);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ namespace Tipoff\EscapeRoom\Tests;
 use Spatie\Permission\PermissionServiceProvider;
 use Tipoff\Authorization\AuthorizationServiceProvider;
 use Tipoff\EscapeRoom\EscapeRoomServiceProvider;
+use Tipoff\Locations\LocationsServiceProvider;
 use Tipoff\Support\SupportServiceProvider;
 use Tipoff\TestSupport\BaseTestCase;
 
@@ -19,6 +20,7 @@ class TestCase extends BaseTestCase
             AuthorizationServiceProvider::class,
             PermissionServiceProvider::class,
             EscapeRoomServiceProvider::class,
+            LocationsServiceProvider::class,
             SupportServiceProvider::class,
             AuthorizationServiceProvider::class,
             PermissionServiceProvider::class,


### PR DESCRIPTION
This originally started to fix what seemed to be just issues with the Nova filters, but I am running into more issues with the tests.

The main issue seems to be the models called from the `tipoff/locations` package. After fixing the psalm errors, I started getting the error:

```
PDOException: SQLSTATE[HY000]: General error: 1 no such table: locations
```

Since the locations package is now included, I tried calling the `LocationFactory` in the `RoomFactory`, but now I'm getting:

```
PDOException: SQLSTATE[HY000]: General error: 1 no such table: markets
```

Am I running astray or are these legitimate issues stemming from the locations package?